### PR TITLE
Added an object detection feature.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,4 +30,4 @@ add_custom_target(
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-add_executable(Z_DUMMY_TARGET ${SRC_LIST} lib/src/driveTask.h)
+add_executable(Z_DUMMY_TARGET ${SRC_LIST} lib/src/driveTask.h lib/src/distanceSensorTask.h)

--- a/lib/src/distanceSensorTask.cpp
+++ b/lib/src/distanceSensorTask.cpp
@@ -1,0 +1,43 @@
+//
+// Created by matt on 4/17/23.
+//
+
+#include <Arduino.h>
+#include "distanceSensorTask.h"
+#include </home/matt/CLionProjects/CarProject/.pio/libdeps/esp32dev/NewPing/src/NewPing.h>
+
+#define FRONT_TRIGGER_PIN 21
+#define FRONT_ECHO_PIN 35
+#define BACK_TRIGGER_PIN 22
+#define BACK_ECHO_PIN 34
+#define BUZZ_PIN 27
+
+//Detection range in centimeters
+const int detectionRange = 15;
+
+void objectDetectionTask(void *parameter) {
+    //Initialize front sonar
+    NewPing frontSonar(FRONT_TRIGGER_PIN, FRONT_ECHO_PIN, detectionRange);
+    //Initialize back sonar
+    NewPing backSonar(BACK_TRIGGER_PIN, BACK_ECHO_PIN, detectionRange);
+    pinMode(BUZZ_PIN, OUTPUT);
+    while (1) {
+        //Delay to avoid watchdog
+        vTaskDelay(10 / portTICK_PERIOD_MS);
+        //Buzz and signal for when both sonars are triggered
+        if ((frontSonar.ping_cm() <= 15 && frontSonar.ping_cm() != 0) && (backSonar.ping_cm() <= 15 && backSonar.ping_cm() != 0)) {
+            digitalWrite(BUZZ_PIN, HIGH);
+            xSemaphoreGive(frontBackObjectDetectionHandle);
+            //Buzz and signal for when front sonar is triggered
+        } else if (frontSonar.ping_cm() <= 15 && frontSonar.ping_cm() != 0) {
+            digitalWrite(BUZZ_PIN, HIGH);
+            xSemaphoreGive(frontObjectDetectionHandle);
+            //Buzz and signal for when back sonar is triggered
+        } else if (backSonar.ping_cm() <= 15 && backSonar.ping_cm() != 0) {
+            digitalWrite(BUZZ_PIN, HIGH);
+            xSemaphoreGive(backObjectDetectionHandle);
+        } else {
+            digitalWrite(BUZZ_PIN, LOW);
+        }
+    }
+}

--- a/lib/src/distanceSensorTask.h
+++ b/lib/src/distanceSensorTask.h
@@ -2,13 +2,12 @@
 // Created by matt on 4/17/23.
 //
 
-#ifndef CARPROJECT_DRIVETASK_H
-#define CARPROJECT_DRIVETASK_H
+#ifndef CARPROJECT_DISTANCESENSORTASK_H
+#define CARPROJECT_DISTANCESENSORTASK_H
 
-#endif //CARPROJECT_DRIVETASK_H
+#endif //CARPROJECT_DISTANCESENSORTASK_H
 
-
-void driveTask(void *parameter);
+void objectDetectionTask(void *parameter);
 extern SemaphoreHandle_t frontBackObjectDetectionHandle;
 extern SemaphoreHandle_t frontObjectDetectionHandle;
 extern SemaphoreHandle_t backObjectDetectionHandle;

--- a/lib/src/driveTask.cpp
+++ b/lib/src/driveTask.cpp
@@ -2,8 +2,8 @@
 // Created by matt on 4/17/23.
 //
 
-#include "driveTask.h"
 #include <Arduino.h>
+#include "driveTask.h"
 #include <esp_now.h>
 #define BACK_LEFT_PIN 13
 #define BACK_LEFT_MOTOR1 12
@@ -74,6 +74,16 @@ void driveTask(void *parameter) {
 
     while (1) {
         //Loops and using PWM, actuates the DC motors based on the received controller values
+        if (xSemaphoreTake(frontBackObjectDetectionHandle, 0) == pdTRUE) {
+            strcpy(savedValue.y, "1850");
+            Serial.println("Forward and backward block!");
+        } else if (xSemaphoreTake(frontObjectDetectionHandle, 0) == pdTRUE) {
+            strcpy(savedValue.y, "4095");
+            Serial.println("Forward block!");
+        } else if (xSemaphoreTake(backObjectDetectionHandle, 0) == pdTRUE) {
+            strcpy(savedValue.y, "0");
+            Serial.println("Backward block!");
+        }
         if (atoi(savedValue.x) <= 1850 && atoi(savedValue.y) <= 1800) {
             //Forward left... duty cycle is dependent on a "flipped" 10-bit y value (joystick up)
             dutyCycle = (atoi(savedValue.y) - 4095) / 16 * -1;
@@ -169,8 +179,8 @@ void driveTask(void *parameter) {
 //Callback function for when data is received from the controller
 void onDataRecv(const uint8_t *mac, const uint8_t *incomingData, int size) {
     memcpy(&savedValue, incomingData, sizeof(savedValue));
-    Serial.print("Saved value X: ");
-    Serial.print(savedValue.x);
-    Serial.print(" Saved value Y: ");
-    Serial.println(savedValue.y);
+    //Serial.print("Saved value X: ");
+    //Serial.print(savedValue.x);
+    //Serial.print(" Saved value Y: ");
+    //Serial.println(savedValue.y);
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,3 +12,4 @@
 platform = espressif32
 board = esp32dev
 framework = arduino
+lib_deps = teckel12/NewPing@^1.9.7

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,13 +2,32 @@
 #include <esp_now.h>
 #include <WiFi.h>
 #include "../lib/src/driveTask.h"
+#include "../lib/src/distanceSensorTask.h"
+
+SemaphoreHandle_t frontBackObjectDetectionHandle;
+SemaphoreHandle_t frontObjectDetectionHandle;
+SemaphoreHandle_t backObjectDetectionHandle;
 
 void setup() {
     Serial.begin(9600);
     WiFi.mode(WIFI_STA);
+
+    frontBackObjectDetectionHandle = xSemaphoreCreateBinary();
+    frontObjectDetectionHandle = xSemaphoreCreateBinary();
+    backObjectDetectionHandle = xSemaphoreCreateBinary();
+    //Task that handles DC motor actuation
     xTaskCreate(
             driveTask,
             "Drive Task",
+            1024,
+            nullptr,
+            1,
+            nullptr
+    );
+    //Task that handles object detection
+    xTaskCreate(
+            objectDetectionTask,
+            "Object Detection Task",
             1024,
             nullptr,
             1,


### PR DESCRIPTION
There are front and back ultrasonic sensors that have a max distance of 15 centimeters. When an object is detected in the front, a "front" semaphore is sent to the drive task that forces the DC motors to actuate backward. Conversely, when an object is detected in the back, a "back" semaphore is sent to the drive task that forces the DC to actuate forward. In the event both sensors are blocked, a third "front and back" semaphore is sent to the drive task that prevents front and back DC motor actuation. Whenever an object is detected, a buzzer (or different digital output device) will be set to high. 
A planned feature is to add in an "override" for the distance sensor task that is toggleable with the joystick's switch.