### PR TITLE
Added in shock detection.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,4 +30,4 @@ add_custom_target(
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-add_executable(Z_DUMMY_TARGET ${SRC_LIST} lib/src/driveTask.h lib/src/distanceSensorTask.h)
+add_executable(Z_DUMMY_TARGET ${SRC_LIST} lib/src/driveTask.h lib/src/distanceSensorTask.h lib/src/distanceSensorTask.cpp)

--- a/lib/src/distanceSensorTask.cpp
+++ b/lib/src/distanceSensorTask.cpp
@@ -22,19 +22,26 @@ void objectDetectionTask(void *parameter) {
     NewPing backSonar(BACK_TRIGGER_PIN, BACK_ECHO_PIN, detectionRange);
     pinMode(BUZZ_PIN, OUTPUT);
     while (1) {
-        //Delay to avoid watchdog
-        vTaskDelay(10 / portTICK_PERIOD_MS);
+        //Deferred interrupt from shock detection ISR
+        if (xSemaphoreTake(interruptObjectDetectionHandle, 0) == pdTRUE) {
+            for (int i = 0; i < 4; ++i) {
+                digitalWrite(BUZZ_PIN, HIGH);
+                vTaskDelay(125 / portTICK_PERIOD_MS);
+                digitalWrite(BUZZ_PIN, LOW);
+                vTaskDelay(125);
+            }
+        } else vTaskDelay(10 / portTICK_PERIOD_MS); //Delay to avoid watchdog
         //Buzz and signal for when both sonars are triggered
         if ((frontSonar.ping_cm() <= 15 && frontSonar.ping_cm() != 0) && (backSonar.ping_cm() <= 15 && backSonar.ping_cm() != 0)) {
-            digitalWrite(BUZZ_PIN, HIGH);
+            //digitalWrite(BUZZ_PIN, HIGH);
             xSemaphoreGive(frontBackObjectDetectionHandle);
             //Buzz and signal for when front sonar is triggered
         } else if (frontSonar.ping_cm() <= 15 && frontSonar.ping_cm() != 0) {
-            digitalWrite(BUZZ_PIN, HIGH);
+            //digitalWrite(BUZZ_PIN, HIGH);
             xSemaphoreGive(frontObjectDetectionHandle);
             //Buzz and signal for when back sonar is triggered
         } else if (backSonar.ping_cm() <= 15 && backSonar.ping_cm() != 0) {
-            digitalWrite(BUZZ_PIN, HIGH);
+            //digitalWrite(BUZZ_PIN, HIGH);
             xSemaphoreGive(backObjectDetectionHandle);
         } else {
             digitalWrite(BUZZ_PIN, LOW);

--- a/lib/src/distanceSensorTask.h
+++ b/lib/src/distanceSensorTask.h
@@ -11,3 +11,4 @@ void objectDetectionTask(void *parameter);
 extern SemaphoreHandle_t frontBackObjectDetectionHandle;
 extern SemaphoreHandle_t frontObjectDetectionHandle;
 extern SemaphoreHandle_t backObjectDetectionHandle;
+extern SemaphoreHandle_t interruptObjectDetectionHandle;

--- a/lib/src/driveTask.h
+++ b/lib/src/driveTask.h
@@ -12,3 +12,4 @@ void driveTask(void *parameter);
 extern SemaphoreHandle_t frontBackObjectDetectionHandle;
 extern SemaphoreHandle_t frontObjectDetectionHandle;
 extern SemaphoreHandle_t backObjectDetectionHandle;
+extern SemaphoreHandle_t interruptDriveHandle;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,13 +8,34 @@ SemaphoreHandle_t frontBackObjectDetectionHandle;
 SemaphoreHandle_t frontObjectDetectionHandle;
 SemaphoreHandle_t backObjectDetectionHandle;
 
+//ISR-related handles and constants
+hw_timer_t *interruptTimer;
+SemaphoreHandle_t interruptDriveHandle;
+SemaphoreHandle_t interruptObjectDetectionHandle;
+BaseType_t taskWoken = pdTRUE;
+const uint16_t divider = 80;
+const uint64_t timerMaxCount = 1000000;
+
+//ISR callback function (stored on RAM) that defers work to the display and LED tasks
+void IRAM_ATTR onTimer() {
+    xSemaphoreGiveFromISR(interruptDriveHandle, &taskWoken);
+    xSemaphoreGiveFromISR(interruptObjectDetectionHandle, &taskWoken);
+}
+
 void setup() {
     Serial.begin(9600);
     WiFi.mode(WIFI_STA);
 
+    pinMode(26, INPUT);
+
+    //Turn the object detection semaphores into one queue?
     frontBackObjectDetectionHandle = xSemaphoreCreateBinary();
     frontObjectDetectionHandle = xSemaphoreCreateBinary();
     backObjectDetectionHandle = xSemaphoreCreateBinary();
+
+    //Interrupt semaphores
+    interruptDriveHandle = xSemaphoreCreateBinary();
+    interruptObjectDetectionHandle = xSemaphoreCreateBinary();
     //Task that handles DC motor actuation
     xTaskCreate(
             driveTask,
@@ -33,8 +54,14 @@ void setup() {
             1,
             nullptr
     );
+    //ISR-related functions
+    interruptTimer = timerBegin(0, divider, true);
+    timerAttachInterrupt(interruptTimer, &onTimer, true);
+    timerAlarmWrite(interruptTimer, timerMaxCount, false);
 }
 
 void loop() {
-
+    if (digitalRead(26) == LOW) {
+        timerAlarmEnable(interruptTimer);
+    }
 }


### PR DESCRIPTION
When a shock is detected, an ISR will defer interrupts to the drive and object detection tasks. Crashing into objects and rapidly accelerating forward and backward will trigger the interrupts. During the interrupts, driving and object detection will be disabled for about 1 second.